### PR TITLE
Update PROMISE'23 special issue deadline on index page

### DIFF
--- a/special_issues/index.md
+++ b/special_issues/index.md
@@ -4,7 +4,7 @@
 - [Predictive Models and Data Analytics in Software Engineering (PROMISE)](2024_SI_PROMISE.md) (submit by April 12, 2025)
 - [Software Engineering and AI for Data Quality](2024_SI_SEA4DQ.md) (submit by December 1, 2024)
 - [Security Testing for Complex Software Systems (SECUTE)](2024_SI_SECUTE.md) (submit by October 31, 2024)
-- [Trends in Predictive Models and Data Analytics in Software Engineering](2023_SI_PROMISE.md) (submit by April 14, 2024)
+- [Trends in Predictive Models and Data Analytics in Software Engineering](2023_SI_PROMISE.md) (submit by  ~~April 14, 2024~~ April 28th, 2024)
 - [Innovations in Software System Testing with Deep Learning](2023_Innovations_in_Software_System_Testing_with_Deep_Learning.md) (submit by ~~January 31, 2024~~ February 28, 2024)
 - [Machine Learning Techniques for Software Quality Evaluation](2022_SI_ML_in_SWQualEval.md) (submit by ~~March 30, 2023~~ April 13, 2023)
 - [Predictive Models and Data Analytics in Software Engineering (PROMISE)](2022_SI_PROMISE.md) (submit by April 15, 2023)


### PR DESCRIPTION
Thanks for the extension! The initial pull forgot to update the date on the index page as well. This pull request fixes that. 

Best,
Steffen