### PR TITLE
PROMISE2024: extend submission deadline

### DIFF
--- a/special_issues/2024_SI_PROMISE.md
+++ b/special_issues/2024_SI_PROMISE.md
@@ -36,7 +36,7 @@ Submitted papers should present original, unpublished work, relevant to one of t
 
 
 ## Schedule
-Submission Deadline: **April 12th, 2025**
+Submission Deadline: **April 26th, 2025**
 
 
 ## Submission Instructions


### PR DESCRIPTION
Extends the submission deadline to April 26th 2025.